### PR TITLE
Change 1 core to 8 cores. With 2g/c this results in 16 gb of RAM bein…

### DIFF
--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -555,7 +555,7 @@ ALGNR2`
 		#SBATCH -e $outDir/merge-%j.err
 		#SBATCH --mem-per-cpu=2G
 		#SBATCH -t 1440
-		#SBATCH -c 1 
+		#SBATCH -c 8 
 		#SBATCH --ntasks=1
 		#SBATCH -d $dependalign
 		#SBATCH -J "${groupname}_merge_${jname}"


### PR DESCRIPTION
…g requested, matching the parallel count and requested memory buffer of the sort commands (8 threads, 14gb.) This should both speed up the sorts and prevent Slurm from killing the job for going over memory.

A few caveats. This works as you would expect on Slurm clusters using con_res (comsumable resources) set to CR_Core_Memory. This asks for 8 cpus (which in CR_Core_Memory means cores 8 cores) and 2gb of memory per core for a total of 16gb. That's pretty much what the sort commands are looking for.

The sort commands run inside of the merge jobs look like: "sort --parallel=8 -S 14G". That means, at a minimum, you need something over 14gb in total from Slurm.

If there's a concern about this running correctly on clusters that use CR_Socket_Memory (i.e. where asking for "-c 8" means asking for 8 entire sockets, (which could be multiple CPUs and in the CPUs, multiple cores, and may not exist in the cluster) there's a potentially more widely compatible fix. 

That's leaving #SBATCH -c as 1, and upping #SBATCH --mem-per-cpu to 15G. That has the downside of sort's 8 threads all running on a single core in a CR_Core_Memory/properly restricted cluster, but the upside of working on clusters with less granular resource allocation.

