### PR TITLE
fixed paths

### DIFF
--- a/CPU/juicer.sh
+++ b/CPU/juicer.sh
@@ -323,7 +323,7 @@ echo -ne "Juicer version $juicer_version;" >> $headfile
 bwa 2>&1 | awk '$1=="Version:"{printf(" BWA %s; ", $2)}' >> $headfile 
 echo -ne "$threads threads; " >> $headfile
 java -version 2>&1 | awk 'NR==1{printf("%s; ", $0);}' >> $headfile 
-${juiceDir}/scripts/juicer_tools -V 2>&1 | awk '$1=="Juicer" && $2=="Tools"{printf("%s; ", $0);}' >> $headfile
+${juiceDir}/common/juicer_tools -V 2>&1 | awk '$1=="Juicer" && $2=="Tools"{printf("%s; ", $0);}' >> $headfile
 echo "$0 $@" >> $headfile
 
 ## ALIGN FASTQ AS SINGLE END, SORT BY READNAME, HANDLE CHIMERIC READS
@@ -358,7 +358,7 @@ then
         then
             usegzip=1
         fi
-	source ${juiceDir}/scripts/common/countligations.sh
+	source ${juiceDir}/common/countligations.sh
 
         # Align read1 
         if [ -n "$shortread" ] || [ "$shortreadend" -eq 1 ]
@@ -443,7 +443,7 @@ then
         # call chimeric_blacklist.awk to deal with chimeric reads; 
         # sorted file is sorted by read name at this point
 	touch $name${ext}_abnorm.sam $name${ext}_unmapped.sam
-	awk -v "fname1"=$name${ext}_norm.txt -v "fname2"=$name${ext}_abnorm.sam -v "fname3"=$name${ext}_unmapped.sam -f ${juiceDir}/scripts/common/chimeric_blacklist.awk $name$ext.sam
+	awk -v "fname1"=$name${ext}_norm.txt -v "fname2"=$name${ext}_abnorm.sam -v "fname3"=$name${ext}_unmapped.sam -f ${juiceDir}/common/chimeric_blacklist.awk $name$ext.sam
 	if [ $? -ne 0 ]
 	then
             echo "***! Failure during chimera handling of $name${ext}"
@@ -453,7 +453,7 @@ then
         # and store that
 	if [ -e "$name${ext}_norm.txt" ] && [ "$site" != "none" ]
 	then
-            ${juiceDir}/scripts/common/fragment.pl $name${ext}_norm.txt $name${ext}.frag.txt $site_file                                                                
+            ${juiceDir}/common/fragment.pl $name${ext}_norm.txt $name${ext}.frag.txt $site_file                                                                
 	elif [ "$site" == "none" ]
 	then
             awk '{printf("%s %s %s %d %s %s %s %d", $1, $2, $3, 0, $4, $5, $6, 1); for (i=7; i<=NF; i++) {printf(" %s",$i);}printf("\n");}' $name${ext}_norm.txt > $name${ext}.frag.txt
@@ -500,7 +500,7 @@ then
     touch ${outputdir}/dups.txt
     touch ${outputdir}/optdups.txt
     touch ${outputdir}/merged_nodups.txt
-    awk -f ${juiceDir}/scripts/common/dups.awk -v name=${outputdir}/ ${outputdir}/merged_sort.txt
+    awk -f ${juiceDir}/common/dups.awk -v name=${outputdir}/ ${outputdir}/merged_sort.txt
     # for consistency with cluster naming in split_rmdups
     mv ${outputdir}/optdups.txt ${outputdir}/opt_dups.txt 
 fi
@@ -519,33 +519,33 @@ then
         export _JAVA_OPTIONS=-Xmx16384m
         export LC_ALL=en_US.UTF-8 
 	tail -n1 $headfile | awk '{printf"%-1000s\n", $0}' > $outputdir/inter.txt;
-        ${juiceDir}/scripts/common/statistics.pl -s $site_file -l $ligation -o $outputdir/stats_dups.txt $outputdir/dups.txt
-        cat $splitdir/*.res.txt | awk -f ${juiceDir}/scripts/common/stats_sub.awk >> $outputdir/inter.txt
-        java -cp ${juiceDir}/scripts/common/ LibraryComplexity $outputdir inter.txt >> $outputdir/inter.txt
-        ${juiceDir}/scripts/common/statistics.pl -s $site_file -l $ligation -o $outputdir/inter.txt -q 1 $outputdir/merged_nodups.txt 
+        ${juiceDir}/common/statistics.pl -s $site_file -l $ligation -o $outputdir/stats_dups.txt $outputdir/dups.txt
+        cat $splitdir/*.res.txt | awk -f ${juiceDir}/common/stats_sub.awk >> $outputdir/inter.txt
+        java -cp ${juiceDir}/common/ LibraryComplexity $outputdir inter.txt >> $outputdir/inter.txt
+        ${juiceDir}/common/statistics.pl -s $site_file -l $ligation -o $outputdir/inter.txt -q 1 $outputdir/merged_nodups.txt 
         cat $splitdir/*_abnorm.sam > $outputdir/abnormal.sam
         cat $splitdir/*_unmapped.sam > $outputdir/unmapped.sam
-        awk -f ${juiceDir}/scripts/common/collisions.awk $outputdir/abnormal.sam > $outputdir/collisions.txt
+        awk -f ${juiceDir}/common/collisions.awk $outputdir/abnormal.sam > $outputdir/collisions.txt
         if [ "$nofrag" -eq 1 ]
         then 
-            ${juiceDir}/scripts/common/juicer_tools pre -s $outputdir/inter.txt -g $outputdir/inter_hists.m -q 1 $outputdir/merged_nodups.txt $outputdir/inter.hic $genomePath
+            ${juiceDir}/common/juicer_tools pre -s $outputdir/inter.txt -g $outputdir/inter_hists.m -q 1 $outputdir/merged_nodups.txt $outputdir/inter.hic $genomePath
         else 
-            ${juiceDir}/scripts/common/juicer_tools pre -f $site_file -s $outputdir/inter.txt -g $outputdir/inter_hists.m -q 1 $outputdir/merged_nodups.txt $outputdir/inter.hic $genomePath 
+            ${juiceDir}/common/juicer_tools pre -f $site_file -s $outputdir/inter.txt -g $outputdir/inter_hists.m -q 1 $outputdir/merged_nodups.txt $outputdir/inter.hic $genomePath 
         fi 
 	tail -n1 $headfile | awk '{printf"%-1000s\n", $0}' > $outputdir/inter_30.txt;
-        cat $splitdir/*.res.txt | awk -f ${juiceDir}/scripts/common/stats_sub.awk >> $outputdir/inter_30.txt
-        java -cp ${juiceDir}/scripts/common/ LibraryComplexity $outputdir inter_30.txt >> $outputdir/inter_30.txt
-        ${juiceDir}/scripts/common/statistics.pl -s $site_file -l $ligation -o $outputdir/inter_30.txt -q 30 $outputdir/merged_nodups.txt
+        cat $splitdir/*.res.txt | awk -f ${juiceDir}/common/stats_sub.awk >> $outputdir/inter_30.txt
+        java -cp ${juiceDir}/common/ LibraryComplexity $outputdir inter_30.txt >> $outputdir/inter_30.txt
+        ${juiceDir}/common/statistics.pl -s $site_file -l $ligation -o $outputdir/inter_30.txt -q 30 $outputdir/merged_nodups.txt
         if [ "$nofrag" -eq 1 ]
         then 
-            ${juiceDir}/scripts/common/juicer_tools pre -s $outputdir/inter_30.txt -g $outputdir/inter_30_hists.m -q 30 $outputdir/merged_nodups.txt $outputdir/inter_30.hic $genomePath 
+            ${juiceDir}/common/juicer_tools pre -s $outputdir/inter_30.txt -g $outputdir/inter_30_hists.m -q 30 $outputdir/merged_nodups.txt $outputdir/inter_30.hic $genomePath 
         else 
-            ${juiceDir}/scripts/common/juicer_tools pre -f $site_file -s $outputdir/inter_30.txt -g $outputdir/inter_30_hists.m -q 30 $outputdir/merged_nodups.txt $outputdir/inter_30.hic $genomePath
+            ${juiceDir}/common/juicer_tools pre -f $site_file -s $outputdir/inter_30.txt -g $outputdir/inter_30_hists.m -q 30 $outputdir/merged_nodups.txt $outputdir/inter_30.hic $genomePath
         fi
     fi
     # POSTPROCESSING
-    ${juiceDir}/scripts/common/juicer_postprocessing.sh -j ${juiceDir}/scripts/common/juicer_tools -i ${outputdir}/inter_30.hic -m ${juiceDir}/references/motif -g ${genomeID}
+    ${juiceDir}/common/juicer_postprocessing.sh -j ${juiceDir}/common/juicer_tools -i ${outputdir}/inter_30.hic -m ${juiceDir}/references/motif -g ${genomeID}
 fi
 #CHECK THAT PIPELINE WAS SUCCESSFUL
 export early=$earlyexit
-source ${juiceDir}/scripts/common/check.sh
+source ${juiceDir}/common/check.sh


### PR DESCRIPTION
the directory structure in the CPU version of the script did not match that of the repo, juicer.sh
was looking for CPU/common/scripts instead of just CPU/common.