### PR TITLE
Update calculate_map_resolution.sh

### DIFF
--- a/misc/calculate_map_resolution.sh
+++ b/misc/calculate_map_resolution.sh
@@ -97,7 +97,7 @@ threshold=$(( $threshold / 5 ))
 
 echo -ne "."
 newbin=50
-bins1000=$(awk '$3>=1000{sum++}END{print sum}' $coveragename)
+bins1000=$(awk '$3>=1000{sum++}END{if (sum == 0) print 0; else print sum}' $coveragename)
 lowrange=$newbin
 
 # find reasonable range with big jumps


### PR DESCRIPTION
When there is no 50 bp bin with 1000 or more counts, the awk command failed to create the "sum" variable, so "bins1000" was NULL. I added a condition for this awk command to return 0 when this happens.