### PR TITLE
Fix for multiple ligation site option -b

### DIFF
--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -274,6 +274,10 @@ if [ ! -e "${refSeq}.bwt" ]; then
     exit 1;
 fi
 
+## Check if ligation is a unquoted regex, if so quote
+if [[ -n "$ligation" && $ligation =~ [\(\)\|] && ! $ligation =~ [\"\'] ]];
+    export ligation="'$ligation'"
+
 ## Set ligation junction based on restriction enzyme
 if [ -z "$ligation" ]; then
     case $site in
@@ -611,7 +615,7 @@ SPLITEND`
                 $userstring			
 
 		date
-		export usegzip=${usegzip}; export name=${name}; export name1=${name1}; export name2=${name2}; export ext=${ext}; export ligation="${ligation}"; ${juiceDir}/scripts/countligations.sh
+		export usegzip=${usegzip}; export name=${name}; export name1=${name1}; export name2=${name2}; export ext=${ext}; export ligation=${ligation}; ${juiceDir}/scripts/countligations.sh
 		date
 CNTLIG`
 	dependcount="$jid"

--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -283,6 +283,7 @@ if [ -z "$ligation" ]; then
 	MboI) ligation="GATCGATC";;
         NcoI) ligation="CCATGCATGG";;
 	MboI+HindIII) ligation="'(GATCGATC|AAGCTAGCTT)'";;
+	Arima) ligation="'(GAATAATC|GAATACTC|GAATAGTC|GAATATTC|GAATGATC|GACTAATC|GACTACTC|GACTAGTC|GACTATTC|GACTGATC|GAGTAATC|GAGTACTC|GAGTAGTC|GAGTATTC|GAGTGATC|GATCAATC|GATCACTC|GATCAGTC|GATCATTC|GATCGATC|GATTAATC|GATTACTC|GATTAGTC|GATTATTC|GATTGATC)'";;
 	none) ligation="XXXX";;
 	*)  ligation="XXXX"
 	    echo "$site not listed as recognized enzyme. Using $site_file as site file"

--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -610,7 +610,7 @@ SPLITEND`
                 $userstring			
 
 		date
-		export usegzip=${usegzip}; export name=${name}; export name1=${name1}; export name2=${name2}; export ext=${ext}; export ligation=${ligation}; ${juiceDir}/scripts/countligations.sh
+		export usegzip=${usegzip}; export name=${name}; export name1=${name1}; export name2=${name2}; export ext=${ext}; export ligation="${ligation}"; ${juiceDir}/scripts/countligations.sh
 		date
 CNTLIG`
 	dependcount="$jid"


### PR DESCRIPTION
If multiple ligation site are specified like so `-b '(ATCG|GCTA)', it creates problems in the script as the regex won't be quoted when substituted into a command. Created a check for unquoted regex. Added the Arima genomics kits ligation profile.