### PR TITLE
Allow users to define memory usage in 'samtools sort'

### DIFF
--- a/PBS/scripts/juicer.sh
+++ b/PBS/scripts/juicer.sh
@@ -621,13 +621,22 @@ ALGNR1
         date +"%Y-%m-%d %H:%M:%S"
         $load_samtools
         export LC_ALL=C
+
+	# Set memory for samtools sort (maximum memory is set above with 'mem=24gb')
+        smemory=$(echo 24 / $threads | bc)
+        if [ "$smemory" -le 1 ]
+        then
+           smemory=1
+        fi
+        smemorystring="-m ${smemory}G"
+
         # call chimeric_blacklist.awk to deal with chimeric reads; sorted file is sorted by read name at this point
         if [ "$site" != "none" ] && [ -e "$site_file" ]
         then
-           awk -v stem=${name}${ext}_norm -v site_file=$site_file -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam | samtools sort -t cb -n $sthreadstring >  ${name}${ext}.bam
+           awk -v stem=${name}${ext}_norm -v site_file=$site_file -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam | samtools sort -t cb -n $sthreadstring $smemorystring > ${name}${ext}.bam
         else
            awk -v stem=${name}${ext}_norm -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam > $name$ext.sam2 
-           awk -v avgInsertFile=${name}${ext}_norm.txt.res.txt -f $juiceDir/scripts/adjust_insert_size.awk $name$ext.sam2 | samtools sort -t cb -n $sthreadstring >  ${name}${ext}.bam 
+           awk -v avgInsertFile=${name}${ext}_norm.txt.res.txt -f $juiceDir/scripts/adjust_insert_size.awk $name$ext.sam2 | samtools sort -t cb -n $sthreadstring $smemorystring > ${name}${ext}.bam
         fi
         if [ \$? -ne 0 ]
         then

--- a/PBS_without_launch/scripts/juicer.sh
+++ b/PBS_without_launch/scripts/juicer.sh
@@ -608,13 +608,22 @@ ALGNR1
         date +"%Y-%m-%d %H:%M:%S"
         $load_samtools
         export LC_ALL=C
+
+        # Set memory for samtools sort (maximum memory is set above with 'mem=24gb')
+        smemory=$(echo 24 / $threads | bc)
+        if [ "$smemory" -le 1 ]
+        then
+           smemory=1
+        fi
+        smemorystring="-m ${smemory}G"
+
         # call chimeric_blacklist.awk to deal with chimeric reads; sorted file is sorted by read name at this point
         if [ "$site" != "none" ] && [ -e "$site_file" ]
         then
-           awk -v stem=${name}${ext}_norm -v site_file=$site_file -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam | samtools sort -t cb -n $sthreadstring >  ${name}${ext}.bam
+           awk -v stem=${name}${ext}_norm -v site_file=$site_file -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam | samtools sort -t cb -n $sthreadstring $smemorystring > ${name}${ext}.bam
         else
            awk -v stem=${name}${ext}_norm -f $juiceDir/scripts/chimeric_sam.awk $name$ext.sam > $name$ext.sam2 
-           awk -v avgInsertFile=${name}${ext}_norm.txt.res.txt -f $juiceDir/scripts/adjust_insert_size.awk $name$ext.sam2 | samtools sort -t cb -n $sthreadstring >  ${name}${ext}.bam 
+           awk -v avgInsertFile=${name}${ext}_norm.txt.res.txt -f $juiceDir/scripts/adjust_insert_size.awk $name$ext.sam2 | samtools sort -t cb -n $sthreadstring $smemorystring > ${name}${ext}.bam
         fi
         if [ $? -ne 0 ]
         then

--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -964,7 +964,7 @@ MRGALL3`
 $userstring
 ${load_samtools}
 #we should probably set the -m based on memory / num of threads
-if time samtools sort -t cb -n -O SAM -@ $sortthreads -l 0 -m 2G $name$ext.sam3 >  ${name}${ext}.sam
+if time samtools sort -t cb -n -O SAM $sthreadstring -l 0 -m 2G $name$ext.sam3 >  ${name}${ext}.sam
 then
    rm -f $name$ext.sam2 $name$ext.sam3
    touch $touchfile
@@ -1326,7 +1326,7 @@ BAMRM`
 		$userstring
 		${load_samtools}                            
 		export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/gpfs0/home/neva/lib
-		samtools sort $sthreadstring ${outputdir}/merged_dedup.bam > ${outputdir}/merged_dedup_sort.bam
+		samtools sort $sthreadstring -m 10G ${outputdir}/merged_dedup.bam > ${outputdir}/merged_dedup_sort.bam
 		/gpfs0/home/neva/bin/MethylDackel extract -F 1024 --keepSingleton --keepDiscordant $refSeq ${outputdir}/merged_dedup_sort.bam 
 		/gpfs0/home/neva/bin/MethylDackel extract -F 1024 --keepSingleton --keepDiscordant --cytosine_report --CHH --CHG $refSeq ${outputdir}/merged_dedup_sort.bam
 		${juiceDir}/scripts/conversion.sh ${outputdir}/merged_dedup_sort.cytosine_report.txt > ${outputdir}/conversion_report.txt


### PR DESCRIPTION
This PR makes the following changes:
- When using `CPU/juicer.sh` and `CPU/mega_from_bams_diploid.sh`, users can define memory per thread in `samtools sort` using `--mem`, for example, `--mem 8G`
- For PBS and Slurm schedulers, the memory per thread setting in `samtools sort` is calculated based on the preexisting resource requests

With the ability to increase the memory per thread setting, it will reduce the number of temporary files produced during sorting. With large dataset, users can set a larger value to prevent the "_Too many open files_" error from happening (e.g. #343), as the default used by `samtools sort` is only 768M per thread.