### PR TITLE
[minor] Replace `theaidenlab` with `aidenlab`

### DIFF
--- a/AWS/README.md
+++ b/AWS/README.md
@@ -1,2 +1,2 @@
-Extensive instructions, including how to create and launch an instance, are 
-available [on the wiki](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-Amazon-Web-Services)
+Extensive instructions, including how to create and launch an instance, are
+available [on the wiki](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-Amazon-Web-Services)

--- a/CPU/README.md
+++ b/CPU/README.md
@@ -4,6 +4,6 @@
 
 Report bugs using the Issues tab. 
 
-Follow the documentation on [the wiki](https://github.com/theaidenlab/juicer/wiki/Installation) for dependencies, directory structure, and usage.
+Follow the documentation on [the wiki](https://github.com/aidenlab/juicer/wiki/Installation) for dependencies, directory structure, and usage.
 
-**PLEASE NOTE:**  The CPU version is fine for small Hi-C experiments, but any reasonably sized experiment will take an extremely long time to run and therefore should be run [on a cluster](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-a-cluster) or [in the cloud](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-Amazon-Web-Services).
+**PLEASE NOTE:**  The CPU version is fine for small Hi-C experiments, but any reasonably sized experiment will take an extremely long time to run and therefore should be run [on a cluster](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-a-cluster) or [in the cloud](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-Amazon-Web-Services).

--- a/Docker/install-dependencies.sh
+++ b/Docker/install-dependencies.sh
@@ -50,8 +50,8 @@ curl -OL "https://github.com/4dn-dcic/pairix/archive/${PAIRIX_VERSION}.zip" && \
     rm -rf "${PAIRIX_VERSION}.zip" "pairix-${PAIRIX_VERSION}"
 
 # Install Juicer
-git clone --branch encode https://github.com/theaidenlab/juicer.git && \    
-    chmod +x juicer/CPU/* juicer/CPU/common/* juicer/misc/* 
+git clone --branch encode https://github.com/aidenlab/juicer.git && \
+    chmod +x juicer/CPU/* juicer/CPU/common/* juicer/misc/*
 #    && \
 #    find -mindepth 1 -maxdepth 1  -type d -not -name "CPU" -not -name ".git" -not -name "misc" | xargs rm -rf
 

--- a/LSF/README.md
+++ b/LSF/README.md
@@ -6,4 +6,4 @@
 
 We do not use LSF in our lab.  We welcome other developers to update the LSF version to be consistent with the AWS LSF-like version.
 
-Report bugs using the Issues tab. See the [documentation on the wiki](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-a-cluster) to understand how to install and run Juicer.
+Report bugs using the Issues tab. See the [documentation on the wiki](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-a-cluster) to understand how to install and run Juicer.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Instructions for installing the latest version of CUDA can be found on the
 
 The native libraries included with Juicer are compiled for CUDA 7 or CUDA 7.5.
 See the [download page for Juicer
-Tools](https://github.com/theaidenlab/juicer/wiki/Download).
+Tools](https://github.com/aidenlab/juicer/wiki/Download).
 
 Other versions of CUDA can be used, but you will need to download the
 respective native libraries from
@@ -115,7 +115,7 @@ If you cannot access a GPU, you can run the [CPU version of HiCCUPS](https://git
 
 ### Building new jars
 
-See the Juicebox documentation at <https://github.com/theaidenlab/Juicebox> for
+See the Juicebox documentation at <https://github.com/aidenlab/Juicebox> for
 details on building new jars of the juicer_tools.
 
 ------------

--- a/SLURM/README.md
+++ b/SLURM/README.md
@@ -1,1 +1,1 @@
-Please see the [wiki](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-a-cluster) for extensive instructions
+Please see the [wiki](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-a-cluster) for extensive instructions

--- a/UGER/README.md
+++ b/UGER/README.md
@@ -1,1 +1,1 @@
-Please see the [wiki](https://github.com/theaidenlab/juicer/wiki/Running-Juicer-on-a-cluster) for extensive instructions
+Please see the [wiki](https://github.com/aidenlab/juicer/wiki/Running-Juicer-on-a-cluster) for extensive instructions


### PR DESCRIPTION
As for now, github.com/theaidenlab redirects to github.com/aidenlab . However, we should not rely on the redirect, and fix it in advance. Just is case. Just for consistency.

Ideally, the same should be done everywhere across the wiki. But that seems to be a much longer task.