### PR TITLE
Fix SLURM account specification: ensure $userstring is correctly parsed by SLURM

### DIFF
--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#SBATCH --account=hammou0
+#SBATCH --partition=standard
 ##########
 #The MIT License (MIT)
 #
@@ -587,7 +589,7 @@ else
 fi
 jid=`sbatch <<- HEADER | egrep -o -e "\b[0-9]+$"
 	#!/bin/bash -l 
-        $userstring
+	$userstring
 	$queuestring
 	#SBATCH -t 2
 	#SBATCH -c 1
@@ -669,7 +671,7 @@ then
 			#SBATCH -o $debugdir/split-%j.out
 			#SBATCH -e $debugdir/split-%j.err
 			#SBATCH -J "${groupname}_split_${i}"
-                        $userstring			
+			$userstring			
 			date
 			echo "Split file: $filename"
 			split -a 3 -l $splitsize -d --additional-suffix=.fastq $i $splitdir/$filename
@@ -685,7 +687,7 @@ SPLITEND`
 			#SBATCH -o $debugdir/split-%j.out
 			#SBATCH -e $debugdir/split-%j.err
 			#SBATCH -J "${groupname}_split_${i}"
-                        $userstring			
+			$userstring			
 			date
 			echo "Split file: $filename"
 			zcat $i | split -a 3 -l $splitsize -d --additional-suffix=.fastq - $splitdir/$filename
@@ -769,7 +771,7 @@ SPLITEND`
 		#SBATCH -e $debugdir/count_ligation-%j.err
 		#SBATCH -J "${groupname}_${jname}_Count_Ligation"
 		#SBATCH --mem=5G
-                $userstring			
+		$userstring			
 
 		date
 		export usegzip=${usegzip}; export name=${name}; export name1=${name1}; export name2=${name2}; export ext=${ext}; export ligation=${ligation}; export singleend=${singleend}; ${juiceDir}/scripts/countligations.sh
@@ -790,7 +792,7 @@ CNTLIG`
 		#SBATCH --mem=$alloc_mem
 		#SBATCH -J "${groupname}_align1_${jname}"
 		#SBATCH --threads-per-core=1		
-                $userstring			
+		$userstring			
 
 		${load_bwa}
 		# Align reads
@@ -847,7 +849,7 @@ ALGNR1`
 		#SBATCH --mem=5G
 		${load_awk}
 		${load_samtools}
-                $userstring			
+		$userstring			
 
 		date
 		echo -ne "0 " > ${name}${ext}_norm.txt.res.txt
@@ -873,7 +875,7 @@ CNTLINE`
 		#SBATCH -d $dependalign
 		#SBATCH -J "${groupname}_merge_${jname}"
                 #SBATCH --threads-per-core=1
-                $userstring
+				$userstring
 		${load_awk}
 
 		date
@@ -901,7 +903,7 @@ MRGALL`
 		#SBATCH -d $dependalign
 		#SBATCH -J "${groupname}_merge_${jname}"
                 #SBATCH --threads-per-core=1
-                $userstring
+				$userstring
 		${load_awk}
 		#time awk -v maxcount=1000000 -f $juiceDir/scripts/calculate_insert_size.awk $name$ext.sam > $name$ext.insert_size
 		#will need to combine chimeric_sam and adjust_insert_size 
@@ -921,7 +923,7 @@ MRGALL1`
 		#SBATCH -d $dependalign
 		#SBATCH -J "${groupname}_merge_${jname}"
                 #SBATCH --threads-per-core=1
-                $userstring
+				$userstring
 		${load_awk}
 		#time awk -v maxcount=1000000 -f $juiceDir/scripts/calculate_insert_size.awk $name$ext.sam > $name$ext.insert_size
 		#will need to combine chimeric_sam and adjust_insert_size 
@@ -940,7 +942,7 @@ MRGALL1`
 		#SBATCH -d $dependalign
 		#SBATCH -J "${groupname}_merge_${jname}"
                 #SBATCH --threads-per-core=1
-                $userstring
+				$userstring
 		${load_awk}
 
 		time awk -v avgInsertFile=${name}${ext}_norm.txt.res.txt -f $juiceDir/scripts/adjust_insert_size.awk $name$ext.sam2 > $name$ext.sam3
@@ -997,7 +999,7 @@ MRGALL2`
 		#SBATCH -p $queue
 		#SBATCH -J "${groupname}_check"
 		#SBATCH -d $dependmerge
-                $userstring			
+				$userstring			
 
 		date
 		echo "Checking $f"
@@ -1050,7 +1052,7 @@ then
 		${sbatch_cpu_alloc}
 		#SBATCH -J "${groupname}_fragmerge"
 		${sbatch_wait}
-                $userstring			
+				$userstring			
 
 		date
 		if [ -f "${errorfile}" ]
@@ -1102,7 +1104,7 @@ then
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_dedup_guard"
 	${sbatch_wait}
-        $userstring			
+	$userstring			
 
 	date
 DEDUPGUARD`
@@ -1121,7 +1123,7 @@ DEDUPGUARD`
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_dedup"
 	${sbatch_wait}
-        $userstring
+	$userstring
 	
 	${load_awk}
 	date
@@ -1158,7 +1160,7 @@ DEDUP`
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_post_dedup"
 	#SBATCH -d ${dependguard}
-        $userstring			
+	$userstring			
 
 	date
 	rm -Rf $tmpdir;
@@ -1195,7 +1197,7 @@ if [ -z $postproc ] && [ -z $final ]
 	#SBATCH --mem-per-cpu=8G
 	#SBATCH -J "${groupname}_dupcheck"
 	${sbatch_wait}
-        $userstring			
+	$userstring			
 	${load_awk}
 	date 
 	wc -l ${outputdir}/merged_sort.sam |  awk '{printf("%s ", \\\$1)}' > $debugdir/dupcheck-${groupname}
@@ -1346,7 +1348,7 @@ METH`
 	#SBATCH --mem=25G
 	#SBATCH -J "${groupname}_stats"
 	${sbatch_wait000}
-        $userstring			
+	$userstring			
 
 	date
 	if [ -f "${errorfile}" ]
@@ -1416,7 +1418,7 @@ then
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_mnd"     
 	${sbatch_wait1}
-        $userstring	   
+	$userstring	   
 	${load_samtools}
 	date
 
@@ -1438,7 +1440,7 @@ MND`
 	#SBATCH -J "${groupname}_prep_done"     
         #SBATCH --mail-type=END,FAIL
 	${sbatch_wait1}
-        $userstring	   
+	$userstring	   
 	date
 	export splitdir=${splitdir}; export outputdir=${outputdir}; export early=1; 
 	if ${juiceDir}/scripts/check.sh 
@@ -1478,7 +1480,7 @@ FINCLN1`
 	#SBATCH --mem=150G
 	#SBATCH -J "${groupname}_hic"
 	${sbatch_waitstats}
-        $userstring			
+	$userstring			
 
 	${load_java}
 	export IBM_JAVA_OPTIONS="-Xmx150000m -Xgcthreads1"
@@ -1516,7 +1518,7 @@ HIC`
 	#SBATCH --mem=150G
 	#SBATCH -J "${groupname}_hic30"
 	${sbatch_waitstats30}
-        $userstring	
+	$userstring	
 
 	${load_java}
 	export IBM_JAVA_OPTIONS="-Xmx150000m -Xgcthreads1"
@@ -1565,7 +1567,7 @@ then
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_hiccups_wrap"
 	${sbatch_wait}
-        $userstring
+	$userstring
 
 	${load_gpu}
 	echo "load: $load_gpu"
@@ -1598,7 +1600,7 @@ then
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_arrowhead_wrap"
 	${sbatch_wait}
-        $userstring			
+	$userstring			
 
 	${load_java}
 	date
@@ -1648,7 +1650,7 @@ jid=`sbatch <<- FINCLN1 | egrep -o -e "\b[0-9]+$"
 	#SBATCH --ntasks=1
 	#SBATCH -J "${groupname}_prep_done"
 	$dependarrows
-        $userstring			
+	$userstring			
 
 	date
 	export splitdir=${splitdir}

--- a/SLURM/scripts/juicer.sh
+++ b/SLURM/scripts/juicer.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#SBATCH --account=hammou0
-#SBATCH --partition=standard
 ##########
 #The MIT License (MIT)
 #


### PR DESCRIPTION
Description:
This pull request updates the way the SLURM account line ($userstring) is inserted into job scripts.
Previously, using spaces instead of tabs could cause SLURM to ignore or misinterpret the account name, resulting in jobs not being assigned to the correct account.
By ensuring the correct formatting (using tabs or proper variable expansion), SLURM now correctly parses the account name from $userstring.

Summary of changes:
Updated all $userstring insertions in the script to use the correct format for SLURM account parsing.